### PR TITLE
Add dotMath package

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -384,6 +384,10 @@
         "listed": true,
         "version": "3.0.0"
     },
+    "dotMath": {
+        "listed": true,
+        "version": "1.5.0"
+    },
     "DotNetty.Buffers": {
         "listed": true,
         "version": "0.7.0"


### PR DESCRIPTION
Package link: https://www.nuget.org/packages/dotMath/

Has .NETStandard2.0 support since 1.5.0
Has been tested in the Editor and Standalone