### PR TITLE
Added GeoTimeZone and TimeZoneConverter to the registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -493,7 +493,7 @@
     },
     "GeoTimeZone": {
         "listed": true,
-        "version": "6.0.0"
+        "version": "5.0.0"
     },
     "Google.Api.CommonProtos": {
         "listed": true,
@@ -1838,7 +1838,7 @@
     },
     "TimeZoneConverter": {
         "listed": true,
-        "version": "7.0.0"
+        "version": "4.0.0"
     },
     "TxFileManager": {
         "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -491,6 +491,10 @@
         "listed": true,
         "version": "[2.0.0,3.0.0)"
     },
+    "GeoTimeZone": {
+        "listed": true,
+        "version": "6.0.0"
+    },
     "Google.Api.CommonProtos": {
         "listed": true,
         "version": "1.7.0"
@@ -1831,6 +1835,10 @@
     "Testably.Abstractions.FileSystem.Interface": {
         "listed": true,
         "version": "0.1.0"
+    },
+    "TimeZoneConverter": {
+        "listed": true,
+        "version": "7.0.0"
     },
     "TxFileManager": {
         "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1838,7 +1838,7 @@
     },
     "TimeZoneConverter": {
         "listed": true,
-        "version": "4.0.0"
+        "version": "2.1.0"
     },
     "TxFileManager": {
         "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -504,7 +504,7 @@
     },
     "GeoTimeZone": {
         "listed": true,
-        "version": "5.0.0"
+        "version": "3.0.0"
     },
     "Google.Api.CommonProtos": {
         "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/GeoTimeZone and https://www.nuget.org/packages/TimeZoneConverter/ 
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


