### PR TITLE
Add System.Xml.XPath.XmlDocument

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -650,7 +650,7 @@
     },
     "HtmlAgilityPack": {
         "listed": true,
-        "version": "1.11.24"
+        "version": "1.5.3"
     },
     "Hyperion": {
         "listed": true,
@@ -1850,6 +1850,10 @@
     "System.Threading.Tasks.Extensions": {
         "listed": false,
         "version": "4.4.0"
+    },
+    "System.Xml.XPath.XmlDocument": {
+        "listed": true,
+        "version": "4.7.0"
     },
     "Telnet": {
         "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -172,8 +172,6 @@ namespace UnityNuGet.Tests
                 @"GraphQL.Client.Serializer.Newtonsoft",
                 // Version 3.1.8 has dependency on `Panic.StringUtils` which doesn't support .netstandard2.0 or 2.1. Rest of versions are fine.
                 @"GraphQL.Client.Serializer.SystemTextJson",
-                // Versions prior to 1.11.24 depend on System.Xml.XPath.XmlDocument which does not target .netstandard2.0
-                @"HtmlAgilityPack",
                 // Although 2.x targets .netstandard2.0 it has an abandoned dependency (Remotion.Linq) that does not target .netstandard2.0.
                 // 3.1.0 is set because 3.0.x only targets .netstandard2.1.
                 @"Microsoft.EntityFrameworkCore.*",


### PR DESCRIPTION
Drop HtmlAgilityPack test exclusion as System.Xml.XPath.XmlDocument gained .netstandard2.0 support, and add it

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/XXX
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
>
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.