### PR TITLE
Update some packages that have analyzers or source generators

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -330,7 +330,8 @@
     },
     "CommunityToolkit.Mvvm": {
         "listed": true,
-        "version": "7.0.1"
+        "version": "7.0.1",
+        "analyzer": true
     },
     "ComradeVanti.CSharpTools.Opt": {
         "listed": true,
@@ -1037,7 +1038,8 @@
     },
     "Microsoft.Extensions.Logging.Abstractions": {
         "listed": true,
-        "version": "2.0.0"
+        "version": "2.0.0",
+        "analyzer": true
     },
     "Microsoft.Extensions.Logging.Configuration": {
         "listed": true,
@@ -1833,7 +1835,8 @@
     },
     "System.Text.Json": {
         "listed": true,
-        "version": "4.6.0"
+        "version": "4.6.0",
+        "analyzer": true
     },
     "System.Threading.Channels": {
         "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/XXX
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

All of these packages were already in the registry; I just added `"analyzer": true` so that their analyzers and source generators will also be included. I'm really hoping to use the `LoggerMessageAttribute` from `Microsoft.Extensions.Logging.Abstractions` for high-performance logging, so hopefully this works!

Also, regarding the above note, does this mean that existing package versions on your OpenUPM server will not be updated to included the analzyer DLLs? Is there a way to manually trigger those updates?