### PR TITLE
Add ZXing.Net

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1979,5 +1979,9 @@
     "ZString": {
         "listed": true,
         "version": "0.1.0"
+    },
+    "ZXing.Net": {
+        "listed": true,
+        "version": "0.16.4"
     }
 }


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/zxing.Net/
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - The package has been tested on Windows, Android and WebGL platforms, here is a sample project I made: [QrGenerator Sample](https://github.com/NeferS/unity-qr-generator)
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - The package depends only on a package that was already added to the registry: [NETStandard.Library](https://www.nuget.org/packages/NETStandard.Library/)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.




