### PR TITLE
Add MemoryPack

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -755,6 +755,27 @@
         "listed": true,
         "version": "1.6.0"
     },
+    "MemoryPack": {
+        "listed": true,
+        "version": "1.21.1"
+    },
+    "MemoryPack.Core": {
+        "listed": true,
+        "version": "1.21.1"
+    },
+    "MemoryPack.Generator": {
+        "listed": true,
+        "version": "1.21.1",
+        "analyzer": true
+    },
+    "MemoryPack.Streaming": {
+        "listed": true,
+        "version": "1.21.1"
+    },
+    "MemoryPack.UnityShims": {
+        "listed": true,
+        "version": "1.21.1"
+    },
     "MessagePack": {
         "listed": true,
         "version": "1.7.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: 
>     * https://www.nuget.org/packages/MemoryPack
>     * https://www.nuget.org/packages/MemoryPack.Core
>     * https://www.nuget.org/packages/MemoryPack.Generator
>     * https://www.nuget.org/packages/MemoryPack.Streaming
>     * https://www.nuget.org/packages/MemoryPack.UnityShims
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [ ] It must provide .NETStandard2.0 assemblies as part of its package
>     * Provided only .NETStandard2.1 assemblies
> - [ ] The lowest version added must be the lowest .NETStandard2.0 version available
>     * Provided lower version that was surely tested in real Unity builds (Win/macOS/Android/iOS/WebGL)
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - The package was tested in standalone players: Win/macOS/Android/iOS/WebGL builds
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


