### PR TITLE
Added Microsoft.CodeAnalysis.CSharp.Scripting

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -878,6 +878,13 @@
         "version": "2.9.0",
         "analyzer": true
     },
+    "Microsoft.CodeAnalysis.Scripting": {
+        "listed": true,
+        "version": "3.0.0",
+        "defineConstraints": [
+            "UNITY_EDITOR"
+        ]
+    },
     "Microsoft.CSharp": {
         "ignore": true
     },

--- a/registry.json
+++ b/registry.json
@@ -861,6 +861,13 @@
             "UNITY_EDITOR"
         ]
     },
+    "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "listed": true,
+        "version": "3.0.0",
+        "defineConstraints": [
+            "UNITY_EDITOR"
+        ]
+    },
     "Microsoft.CodeAnalysis.NetAnalyzers": {
         "listed": true,
         "version": "5.0.3",

--- a/registry.json
+++ b/registry.json
@@ -868,6 +868,13 @@
             "UNITY_EDITOR"
         ]
     },
+    "Microsoft.CodeAnalysis.CSharp.Scripting.Common": {
+        "listed": true,
+        "version": "3.0.0",
+        "defineConstraints": [
+            "UNITY_EDITOR"
+        ]
+    },
     "Microsoft.CodeAnalysis.NetAnalyzers": {
         "listed": true,
         "version": "5.0.3",

--- a/registry.json
+++ b/registry.json
@@ -892,6 +892,13 @@
             "UNITY_EDITOR"
         ]
     },
+    "Microsoft.CodeAnalysis.Scripting.Common": {
+        "listed": true,
+        "version": "3.0.0",
+        "defineConstraints": [
+            "UNITY_EDITOR"
+        ]
+    },
     "Microsoft.CSharp": {
         "ignore": true
     },

--- a/registry.json
+++ b/registry.json
@@ -868,13 +868,6 @@
             "UNITY_EDITOR"
         ]
     },
-    "Microsoft.CodeAnalysis.CSharp.Scripting.Common": {
-        "listed": true,
-        "version": "3.0.0",
-        "defineConstraints": [
-            "UNITY_EDITOR"
-        ]
-    },
     "Microsoft.CodeAnalysis.NetAnalyzers": {
         "listed": true,
         "version": "5.0.3",


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp.Scripting
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


