### PR TITLE
Add Microsoft.Extensions.Telemetry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1358,9 +1358,17 @@
         "listed": true,
         "version": "8.0.0"
     },
+    "Polly.Extensions": {
+        "listed": true,
+        "version": "8.0.0"
+    },
     "Polly.Extensions.Http": {
         "listed": true,
         "version": "2.0.1"
+    },
+    "Polly.RateLimiting": {
+        "listed": true,
+        "version": "8.0.0"
     },
     "Portable.BouncyCastle": {
         "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -936,6 +936,10 @@
         "listed": true,
         "version": "[3.1.0,6.0.0)"
     },
+    "Microsoft.Extensions.AmbientMetadata.Application": {
+        "listed": true,
+        "version": "9.8.0"
+    },
     "Microsoft.Extensions.Caching.Abstractions": {
         "listed": true,
         "version": "2.0.0"
@@ -1000,6 +1004,10 @@
         "listed": true,
         "version": "2.0.0"
     },
+    "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "listed": true,
+        "version": "9.8.0"
+    },
     "Microsoft.Extensions.DependencyModel": {
         "listed": true,
         "version": "3.0.0"
@@ -1011,6 +1019,10 @@
     "Microsoft.Extensions.Diagnostics.Abstractions": {
         "listed": true,
         "version": "8.0.0"
+    },
+    "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "listed": true,
+        "version": "9.8.0"
     },
     "Microsoft.Extensions.Features": {
         "listed": true,
@@ -1044,9 +1056,17 @@
         "listed": true,
         "version": "2.1.0"
     },
+    "Microsoft.Extensions.Http.Diagnostics": {
+        "listed": true,
+        "version": "9.8.0"
+    },
     "Microsoft.Extensions.Http.Polly": {
         "listed": true,
         "version": "2.1.0"
+    },
+    "Microsoft.Extensions.Http.Resilience": {
+        "listed": true,
+        "version": "9.8.0"
     },
     "Microsoft.Extensions.Localization.Abstractions": {
         "listed": true,
@@ -1107,6 +1127,18 @@
     "Microsoft.Extensions.Primitives": {
         "listed": true,
         "version": "2.0.0"
+    },
+    "Microsoft.Extensions.Resilience": {
+        "listed": true,
+        "version": "9.8.0"
+    },
+    "Microsoft.Extensions.Telemetry": {
+        "listed": true,
+        "version": "9.8.0"
+    },
+    "Microsoft.Extensions.Telemetry.Abstractions": {
+        "listed": true,
+        "version": "9.8.0"
     },
     "Microsoft.Identity.Abstractions": {
         "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Microsoft.Extensions.Telemetry
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


