### PR TITLE
Bump NUnit.Analyzers upper limit to v3.9

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1346,7 +1346,7 @@
     },
     "NUnit.Analyzers": {
         "listed": true,
-        "version": "[2.0.0,3.3.0]",
+        "version": "[2.0.0,3.9.0]",
         "analyzer": true
     },
     "ObservableCollections": {


### PR DESCRIPTION
When [NUnit.Analyzers](https://www.nuget.org/packages/NUnit.Analyzers) were registered; they only worked up to v3.3 on Unity, but now they support up to v3.9.

v3.10 and later are for NUnit4 and are therefore excluded.

