### PR TITLE
Set IDisposableAnalyzers upper limit to v4.0.4

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -672,7 +672,7 @@
     },
     "IDisposableAnalyzers": {
         "listed": true,
-        "version": "1.0.0",
+        "version": "[1.0.0,4.0.4]",
         "analyzer": true
     },
     "IndexRange": {


### PR DESCRIPTION
IDisposableAnalyzers compiler has been upgraded to Roslyn v4.5.0 from IDisposableAnalyzers v4.0.5.

It doesn't work with Unity 6 either, so I set an upper limit.