### PR TITLE
Remove SourceCraftCommunity.SimplifiedCSharp

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1822,10 +1822,6 @@
         "version": "8.30.0.37606",
         "analyzer": true
     },
-    "SourceCraftCommunity.SimplifiedCSharp": {
-        "listed": true,
-        "version": "1.1.0"
-    },
     "SourceGear.sqlite3": {
         "listed": true,
         "version": "3.50.3"


### PR DESCRIPTION
>  The owner has unlisted this package. This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.

https://www.nuget.org/packages/SourceCraftCommunity.SimplifiedCSharp/